### PR TITLE
Experimental initial commit for discussion

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,11 @@
+{erl_opts, [debug_info]}.
+{xrl_opts, [{report, true}, {verbose, true}]}.
+{deps, []}.
+{dialyzer, [{warnings, [unknown]}]}.
+
+{plugins, 
+     [{rebar_prv_alpaca, 
+       ".*", 
+       {git, "https://github.com/j14159/rebar_prv_alpaca.git", {branch, "no-apc"}}}]}.
+
+{provider_hooks, [{post, [{compile, {alpaca, compile}}]}]}.

--- a/src/alpaca_lib.app.src
+++ b/src/alpaca_lib.app.src
@@ -1,0 +1,17 @@
+{application, alpaca_lib,
+ [{description, "alpaca_lib"},
+  {vsn, "0.1.0"},
+  {registered, []},
+  {mod, {'alpaca_lib_app', []}},
+  {applications,
+   [compiler,
+    kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+
+  {contributors, []},
+  {licenses, []},
+  {links, []}
+ ]}.

--- a/src/assert.alp
+++ b/src/assert.alp
@@ -1,0 +1,10 @@
+{- Test helpers, simple assertions.
+ -}
+module assert
+
+export equal
+
+let equal a b =
+  match (a == b) with
+      true -> :ok
+    | false    -> throw (:not_equal, a, b)

--- a/src/option.alp
+++ b/src/option.alp
@@ -1,0 +1,25 @@
+{- Basic option type, otherwise known as "Maybe".
+ -}
+module option
+
+export_type option
+
+export some, map
+
+type option 'a = Some 'a | None
+
+let some a = Some a
+
+let ident x = x
+
+let map f None = None
+
+test "mapping None should produce None" =
+  let f x = x in
+  assert.equal (None) (map f None)
+
+let map f Some a = Some (f a)
+
+test "mapping the identity function to Some x should return Some x" =
+  let f x = x in
+  assert.equal (Some 1) (map f (Some 1))


### PR DESCRIPTION
@lepoetemaudit I don't think we should merge this, I just wanted to try piecing a few things together so that we could talk about what might make sense.  I expect you have some particular ideas about the direction this library should take and I want to stay out of the way for that since you have a pile of experience with both Elm and OCaml.  A few things came up while cobbling this together, really just for kicks:

- there was a typer bug for tests that I've submitted a PR for in Alpaca itself
- the alpaca shell included in the rebar3 plugin is conflicting with us using private forks of Alpaca and the master branch of the plugin has some particular versions locked.  This PR points at my own rebar3 plugin fork that targets my `alpaca/master` and removes the dep on `apcshell`.  I don't want to actually pull the shell out, just needed a way to test against my own master without the conflict :)
- this `rebar.config` doesn't isolate our use of the rebar3 plugin to tests only.

@tsloughter I fixed a minor bug in the rebar3 plugin in my fork's `no-apc` branch, I'll submit a clean PR For that shortly along with trimming `rebar.lock`.