### PR TITLE
Initial work to get an option module

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,11 @@
+{erl_opts, [debug_info]}.
+{xrl_opts, [{report, true}, {verbose, true}]}.
+{deps, []}.
+{dialyzer, [{warnings, [unknown]}]}.
+
+{plugins, 
+     [{rebar_prv_alpaca, 
+       ".*", 
+       {git, "https://github.com/j14159/rebar_prv_alpaca.git", {branch, "no-apc"}}}]}.
+
+{provider_hooks, [{post, [{compile, {alpaca, compile}}]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -3,9 +3,10 @@
 {deps, []}.
 {dialyzer, [{warnings, [unknown]}]}.
 
-{plugins, 
-     [{rebar_prv_alpaca, 
-       ".*", 
-       {git, "https://github.com/j14159/rebar_prv_alpaca.git", {branch, "no-apc"}}}]}.
-
-{provider_hooks, [{post, [{compile, {alpaca, compile}}]}]}.
+{profiles, [{test, [{plugins,
+                     [{rebar_prv_alpaca,
+                       ".*",
+                       {git, 
+                        "https://github.com/alpaca-lang/rebar_prv_alpaca.git", 
+                        {branch, "master"}}}]},
+                    {provider_hooks, [{post, [{compile, {alpaca, compile}}]}]}]}]}.

--- a/src/alpaca_lib.app.src
+++ b/src/alpaca_lib.app.src
@@ -1,0 +1,17 @@
+{application, alpaca_lib,
+ [{description, "alpaca_lib"},
+  {vsn, "0.1.0"},
+  {registered, []},
+  {mod, {'alpaca_lib_app', []}},
+  {applications,
+   [compiler,
+    kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+
+  {contributors, []},
+  {licenses, []},
+  {links, []}
+ ]}.

--- a/src/assert.alp
+++ b/src/assert.alp
@@ -1,0 +1,10 @@
+{- Test helpers, simple assertions.
+ -}
+module assert
+
+export equal
+
+let equal a b =
+  match (a == b) with
+      true -> :ok
+    | false    -> throw (:not_equal, a, b)

--- a/src/option.alp
+++ b/src/option.alp
@@ -1,0 +1,25 @@
+{- Basic option type, otherwise known as "Maybe".
+ -}
+module option
+
+export_type option
+
+export some, map
+
+type option 'a = Some 'a | None
+
+let some a = Some a
+
+let ident x = x
+
+let map f None = None
+
+test "mapping None should produce None" =
+  let f x = x in
+  assert.equal (None) (map f None)
+
+let map f Some a = Some (f a)
+
+test "mapping the identity function to Some x should return Some x" =
+  let f x = x in
+  assert.equal (Some 1) (map f (Some 1))

--- a/src/option.alp
+++ b/src/option.alp
@@ -1,4 +1,5 @@
-{- Basic option type, otherwise known as "Maybe".
+{- Basic option type.  Safely operate on values that may or may not be
+   undefined.
  -}
 module option
 
@@ -8,10 +9,39 @@ export some, map
 
 type option 'a = Some 'a | None
 
+{- Convenience method to generate a non-empty option.
+ -}
 let some a = Some a
 
-let ident x = x
+test "Applying `some` to a literal value yields a non-empty option" =
+  let o = some 1 in
+  assert.equal Some 1 o
 
+{- Transform the contents of an option with a function to make a new option.
+
+   If the option is `None`, the output will be `None` without running the
+   supplied function.
+   If the option contains something (`Some`) then the result will be a full
+   option, the type of which is dictated by the supplied function.
+
+   For example, the supplied function here will not actually be run, the result
+   of this expression is still `None`:
+
+   ```map (fn x -> x + x) None```
+
+   Whereas here the result will be `4`:
+
+   ```map (fn x -> x + x) Some 2```
+
+   The output type is dependent on the supplied function so if we have a function
+   `int_to_string` with the type `int -> string`, the following will yield an
+   `option string`:
+
+   ```
+   -- the result will be Some "2":
+   map int_to_string Some 2```
+   ```
+ -}
 let map f None = None
 
 test "mapping None should produce None" =
@@ -23,3 +53,11 @@ let map f Some a = Some (f a)
 test "mapping the identity function to Some x should return Some x" =
   let f x = x in
   assert.equal (Some 1) (map f (Some 1))
+
+test "mapping double function should double the option" =
+  let double x = x + x in
+  assert.equal Some 2 (map double (Some 1))
+
+test "doubling a float option should result yield correct results" =
+  let double x = x +. x in
+  assert.equal Some 7.0 (map double Some 3.5)


### PR DESCRIPTION
Uses the rebar3 Alpaca plugin only in the test profile which I think will keep things clean for projects depending on this library.

Simple option type included, I've interleaved different function heads for `map/2` and associated tests, not 100% sure I like this style yet but it's growing on me a bit.  Might be cleaner if we had a way to provide multiple test cases in a single `test` hook.  I've followed a potential documentation format with `map/2`, curious as to what others think of this.  I'd like the code blocks in the docs to actually be type checked, compiled, and run as tests too but might be getting ahead of myself.